### PR TITLE
Built a shader which implements the Overlay blend mode.

### DIFF
--- a/source/shaders/OverlayShader.hx
+++ b/source/shaders/OverlayShader.hx
@@ -1,0 +1,49 @@
+package;
+
+import flixel.system.FlxAssets.FlxShader;
+import openfl.display.BitmapData;
+
+/**
+ * Implements the overlay blend mode as a Flixel shader.
+ * 
+ * @see https://en.wikipedia.org/wiki/Blend_modes#Overlay
+ * @author EliteMasterEric
+ */
+class OverlayShader extends FlxShader
+{
+	@:glFragmentSource('
+		#pragma header
+
+        // Takes an image as the input.
+        uniform sampler2D bitmapOverlay;
+
+        vec4 blendOverlay(vec4 base, vec4 blend)
+        {
+            // Depending on the base color, compute a linear interpolation
+            // between black (base layer = 0), the top layer (base layer = 0.5), and white (base layer = 1.0)
+            return mix(1.0 - 2.0 * (1.0 - base) * (1.0 - blend), 2.0 * base * blend, step(base, vec4(0.5)));
+        }
+
+		void main()
+		{
+            // Get the current pixel from the base layer.
+			vec4 base = texture2D(bitmap, openfl_TextureCoordv);
+            // Get the current pixel from the overlay layer.
+            vec4 blend = texture2D(bitmapOverlay, openfl_TextureCoordv);
+            // Compute the overlay blend mode.
+			gl_FragColor = blendOverlay(base, blend);
+		}')
+	public function new()
+	{
+		super();
+	}
+
+	/**
+	 * Assigns the bitmap to be used as the overlay.
+	 * @param bitmap A BitmapData object containing the image to use as the overlay.
+	 */
+	public function setBitmapOverlay(bitmap:BitmapData):Void
+	{
+		this.bitmapOverlay.input = bitmap;
+	}
+}


### PR DESCRIPTION
**Overlay as seen in Adobe Animate:**

![image](https://user-images.githubusercontent.com/4635334/209928146-37938e47-5ccb-4972-bf02-d6b551e78e3d.png)

**Overlay as seen in test bench:**

![image](https://user-images.githubusercontent.com/4635334/209928240-95a1f3d4-ad40-4023-9189-620852a2e4fc.png)

**How to use:**

```
// Retrieve BitmapData for an image (FlxGraphic won't work).
var overlayImage:BitmapData = Assets.getBitmapData("assets/image/overlay.png");

// Instantiate the shader and assign the bitmap data to it.
var overlayShader:OverlayShader = new OverlayShader();
overlayShader.setBitmapOverlay(overlayImage);

// This shader will now overlay the assigned image onto any sprite you assign it to.
sprite.shader = overlayShader;

// You can also use a filter to assign the shader to a camera.
var overlayFilter:ShaderFilter = new ShaderFilter(overlayShader);
FlxG.camera.setFilters([overlayFilter]);
```

If you use this maybe add me to the credits/special thanks? 🥺